### PR TITLE
Remove obsolete defaults key `FLEKSY_SETTINGS_DISPLAY_LANGUAGE`

### DIFF
--- a/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp/SettingsSDK.swift
+++ b/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp/SettingsSDK.swift
@@ -23,8 +23,6 @@ struct SettingsSDK {
                                         allItemsGetter: {
                                             return FontSelectionItem.getAllFontSelectionItems()
                                         })),
-            .bool(BoolSetting(titleKey: "Show language on spacebar",
-                              key: FLEKSY_SETTINGS_DISPLAY_LANGUAGE)),
             .selection(SelectionSetting(titleKey: "Special key",
                                         subtitleKey: "Change the function of the button to the left of the spacebar",
                                         orderingKey: FLEKSY_SETTINGS_MAGIC_BUTTON_ORDER,


### PR DESCRIPTION
The setting can now be applied with `StyleConfiguration`'s `spacebarStyle`