### PR TITLE
FSDK-1230 - Fix potential in-app keyboard crash

### DIFF
--- a/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp/CustomViews/InAppKeyboardTextField.swift
+++ b/keyboardsdk-integrations/keyboard-ios/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp/CustomViews/InAppKeyboardTextField.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class InAppKeyboardTextField: UITextField {
 
-    private let keyboardViewController = KeyboardViewController()
+    private lazy var keyboardViewController = KeyboardViewController()
     
     override var inputViewController: UIInputViewController? {
         return keyboardViewController


### PR DESCRIPTION
🐛 Have `InAppKeyboardTextField` create the `KeyboardViewController` lazily to avoid crash when the keyboard is not opened after all