### PR TITLE
sample: add inapp text field using compose

### DIFF
--- a/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/build.gradle.kts
+++ b/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/build.gradle.kts
@@ -36,6 +36,11 @@ android {
 
     buildFeatures {
         viewBinding = true
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.11"
     }
 }
 
@@ -48,7 +53,12 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
 
-    implementation("co.thingthing.fleksycore:fleksycore-release:4.7.2")
+    implementation("co.thingthing.fleksycore:fleksycore-release:4.8.0")
+
+    val composeBom = platform("androidx.compose:compose-bom:2024.04.01")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+    implementation("androidx.compose.material3:material3")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/build.gradle.kts
+++ b/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
 
-    implementation("co.thingthing.fleksycore:fleksycore-release:4.8.0")
+    implementation("co.thingthing.fleksycore:fleksycore-release:4.9.0")
 
     val composeBom = platform("androidx.compose:compose-bom:2024.04.01")
     implementation(composeBom)

--- a/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/src/main/java/com/fleksy/inappkeyboardadvanced/views/HostFragment.kt
+++ b/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/src/main/java/com/fleksy/inappkeyboardadvanced/views/HostFragment.kt
@@ -4,10 +4,35 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import co.thingthing.fleksy.core.keyboard.inapp.FleksyEditText
 import co.thingthing.fleksy.core.keyboard.inapp.InAppFragmentListener
+import com.fleksy.inappkeyboardadvanced.R
 import com.fleksy.inappkeyboardadvanced.databinding.FragmentHostBinding
+
+@Composable
+fun ComposeFleksyTextField(inAppFragmentListener: InAppFragmentListener) {
+    val editHint = stringResource(id = R.string.try_this_edittext)
+    AndroidView(
+        factory = { context ->
+            val edit = FleksyEditText(context)
+            edit.hint = editHint
+            edit
+        },
+        update = {
+            inAppFragmentListener.registerEditText(it, null)
+        }
+    )
+}
 
 class HostFragment : Fragment() {
 
@@ -28,6 +53,10 @@ class HostFragment : Fragment() {
 
         inAppFragmentListener = requireActivity() as InAppFragmentListener
         inAppFragmentListener.onCreate()
+
+        binding.composeView.setContent {
+            ComposeFleksyTextField(inAppFragmentListener)
+        }
 
         setupButtons()
     }

--- a/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/src/main/res/layout/fragment_host.xml
+++ b/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/app/src/main/res/layout/fragment_host.xml
@@ -14,10 +14,19 @@
         android:imeOptions="actionDone"
         android:inputType="textCapSentences|text"
         android:singleLine="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/compose_view"/>
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintTop_toBottomOf="@+id/tryEditText"
+        app:layout_constraintBottom_toTopOf="@+id/btBottomSheet"/>
 
     <Button
         android:id="@+id/btBottomSheet"

--- a/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/build.gradle.kts
+++ b/Examples/InAppKeyboard/android/InAppkeyboardAdvanced/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
 }


### PR DESCRIPTION
Added a simple example on how to use our in app keyboard in a Compose view inside our Android view-based example