### PR TITLE
Android Integration Sample: Update SDK to version 4.11.0

### DIFF
--- a/Integration/Keyboard-Android/README.md
+++ b/Integration/Keyboard-Android/README.md
@@ -15,8 +15,8 @@ Once integrated, you can see an actual custom keyboard on your device.
 
 ## Development
 
-To build this project, please set both license and secret keys as `FLEKSY_LICENSE_KEY` and `FLEKSY_SECRET_KEY`
-in your respective build environment to populate the `BuildConfig` variables at build time.
+To build this project, please set both license and secret keys as `fleksy_license_key` and `fleksy_license_secret`
+in your respective project properties to populate the `BuildConfig` variables at build time.
 
 ## Fleksy Apps
 1. The included GIPHY app requires a GIPHY API key to run properly. You must provide your own. You may [request one here](https://support.giphy.com/hc/en-us/articles/360020283431-Request-A-GIPHY-API-Key).

--- a/Integration/Keyboard-Android/app/build.gradle
+++ b/Integration/Keyboard-Android/app/build.gradle
@@ -17,8 +17,8 @@ android {
         multiDexEnabled true
 
         // License and Secret key, read from environment
-        buildConfigField "String", "FLEKSY_LICENSE_KEY", "\"$System.env.FLEKSY_LICENSE_KEY\""
-        buildConfigField "String", "FLEKSY_SECRET_KEY", "\"$System.env.FLEKSY_SECRET_KEY\""
+        buildConfigField "String", "FLEKSY_LICENSE_KEY", "\"${project.properties["fleksy_license_key"].toString()}\""
+        buildConfigField "String", "FLEKSY_SECRET_KEY", "\"${project.properties["fleksy_license_secret"].toString()}\""
     }
 
     buildTypes {
@@ -30,6 +30,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 
     compileOptions {
@@ -62,6 +63,6 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 
 	// Keyboard Dependencies
-	implementation "co.thingthing.fleksycore:fleksycore-release:4.7.2"
+	implementation "co.thingthing.fleksycore:fleksycore-release:4.11.0"
 	implementation("co.thingthing.fleksyapps:giphy:2.1.0")
 }

--- a/Integration/Keyboard-Android/gradle.properties
+++ b/Integration/Keyboard-Android/gradle.properties
@@ -23,5 +23,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false


### PR DESCRIPTION
Android Integration Sample: Update SDK to version 4.11.0
Android Integration Sample: Update license credential definition.
Android Integration Sample: Migrated from deprecated BuildConfig to Gradle Build Files.