### PR TITLE
iOS Examples tweaks

### DIFF
--- a/Examples/OpenView/ios/KeyboardOpenView/KeyboardOpenView.xcodeproj/project.pbxproj
+++ b/Examples/OpenView/ios/KeyboardOpenView/KeyboardOpenView.xcodeproj/project.pbxproj
@@ -607,7 +607,7 @@
 			repositoryURL = "https://github.com/FleksySDK/FleksySDK-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.25.0;
+				minimumVersion = 4.28.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Examples/OpenView/ios/KeyboardOpenView/keyboard/KeyboardOpenViewCustom.swift
+++ b/Examples/OpenView/ios/KeyboardOpenView/keyboard/KeyboardOpenViewCustom.swift
@@ -31,7 +31,7 @@ class KeyboardOpenViewCustom : KeyboardApp{
     }
     
     var defaultViewMode: KeyboardAppViewMode {
-        .fullCover() // Shows the view over the keyboard, i.e. covering it.
+        .fullCover(height: .automatic) // Shows the view over the keyboard, i.e. covering it.
     }
     
     ///
@@ -93,10 +93,12 @@ class KeyboardOpenViewCustom : KeyboardApp{
         
         // Add constraints for cosmetics
         NSLayoutConstraint.activate([
-            btnClose.trailingAnchor.constraint(equalTo: exampleView.leadingAnchor, constant: -5),
+            btnClose.trailingAnchor.constraint(equalTo: exampleView.trailingAnchor, constant: -5),
             btnClose.topAnchor.constraint(equalTo: exampleView.topAnchor, constant: 5),
             btnClose.widthAnchor.constraint(equalToConstant: 85),
-            btnClose.heightAnchor.constraint(equalToConstant: 25)
+            btnClose.heightAnchor.constraint(equalToConstant: 25),
+            
+            exampleView.heightAnchor.constraint(equalToConstant: 80),
         ])
 
         btnClose.addTarget(self, action: #selector(hideMyself), for: .touchUpInside)

--- a/Examples/TopBar/iOS/StickyCustomTopBar/keyboard/KeyboardFrameViewCustom.swift
+++ b/Examples/TopBar/iOS/StickyCustomTopBar/keyboard/KeyboardFrameViewCustom.swift
@@ -37,7 +37,7 @@ class KeyboardFrameViewCustom : KeyboardApp, AppTextFieldDelegate {
     ///
     /// Override this property if your FleksyApp needs a different initial view mode.
     open var defaultViewMode: KeyboardAppViewMode {
-        .frame(barMode: .default, height: .default)
+        .frame(barMode: .default, height: .automatic)
     }
     
     ///
@@ -94,6 +94,7 @@ class KeyboardFrameViewCustom : KeyboardApp, AppTextFieldDelegate {
             label.centerYAnchor.constraint(equalTo: exampleView.centerYAnchor),
             label.widthAnchor.constraint(equalToConstant: 300),
             label.heightAnchor.constraint(lessThanOrEqualTo: exampleView.heightAnchor),
+            exampleView.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
         ])
         
         self.exampleView = exampleView


### PR DESCRIPTION
* fix: KeyboardOpenView iOS example now shows hide button in custom view and automatic height
* feat: update StickyCustomTopBar iOS example to use automatic height (i.e. given by the custom view's autolayout constraints)