### PR TITLE
Adapt to future FleksyKeyboardSDK v5

### DIFF
--- a/Examples/Style/iOS/KeyboardStyle/keyboard/KeyboardStyle.swift
+++ b/Examples/Style/iOS/KeyboardStyle/keyboard/KeyboardStyle.swift
@@ -6,7 +6,7 @@
 //  Licensed under the MIT license. See LICENSE file in the project root for details
 //
 
-import Foundation
+import UIKit
 import FleksyKeyboardSDK
 
 enum KeyboardStyle: Int {

--- a/Integration/Keyboard-iOS/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp/SettingModels.swift
+++ b/Integration/Keyboard-iOS/FleksyKeyboardSDKApp/FleksyKeyboardSDKApp/SettingModels.swift
@@ -6,7 +6,7 @@
 //  Licensed under the MIT license. See LICENSE file in the project root for details
 //
 
-import Foundation
+import UIKit
 import FleksyKeyboardSDK
 
 enum SettingModel {


### PR DESCRIPTION
feat: [FSDK-2310] make iOS Sample projects compatible with next major release v5 of FleksyKeyboardSDK

[FSDK-2310]: https://thingthing.atlassian.net/browse/FSDK-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ